### PR TITLE
add instance.Orphan

### DIFF
--- a/massdriver/internal/gen/genqlient.graphql
+++ b/massdriver/internal/gen/genqlient.graphql
@@ -1140,6 +1140,22 @@ mutation CopyInstance(
   }
 }
 
+mutation OrphanInstance($organizationId: ID!, $id: ID!, $input: OrphanInstanceInput!) {
+  orphanInstance(organizationId: $organizationId, id: $id, input: $input) {
+    result {
+      id
+      name
+      status
+    }
+    successful
+    messages {
+      code
+      field
+      message
+    }
+  }
+}
+
 
 # INSTANCE ALARMS
 

--- a/massdriver/internal/gen/genqlient.graphql
+++ b/massdriver/internal/gen/genqlient.graphql
@@ -1156,7 +1156,6 @@ mutation OrphanInstance($organizationId: ID!, $id: ID!, $input: OrphanInstanceIn
   }
 }
 
-
 # INSTANCE ALARMS
 
 query GetInstanceAlarm($organizationId: ID!, $id: UUID!) {

--- a/massdriver/internal/gen/zz_generated.go
+++ b/massdriver/internal/gen/zz_generated.go
@@ -19016,6 +19016,176 @@ var AllOrganizationSubscriptionStatus = []OrganizationSubscriptionStatus{
 	OrganizationSubscriptionStatusPaymentFailed,
 }
 
+// Reset an instance to INITIALIZED, clearing all of its Terraform/OpenTofu state locks. Optionally also deletes the remote IaC state files.
+type OrphanInstanceInput struct {
+	// When true, permanently deletes the instance's Terraform/OpenTofu state files. The next deployment will provision from scratch. Cannot be undone.
+	DeleteState bool `json:"deleteState"`
+}
+
+// GetDeleteState returns OrphanInstanceInput.DeleteState, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceInput) GetDeleteState() bool { return v.DeleteState }
+
+// OrphanInstanceOrphanInstanceInstancePayload includes the requested fields of the GraphQL type InstancePayload.
+type OrphanInstanceOrphanInstanceInstancePayload struct {
+	// The object created/updated/deleted by the mutation. May be null if mutation failed.
+	Result OrphanInstanceOrphanInstanceInstancePayloadResultInstance `json:"result"`
+	// Indicates if the mutation completed successfully or not.
+	Successful bool `json:"successful"`
+	// A list of failed validations. May be blank or null if mutation succeeded.
+	Messages []OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage `json:"messages"`
+}
+
+// GetResult returns OrphanInstanceOrphanInstanceInstancePayload.Result, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayload) GetResult() OrphanInstanceOrphanInstanceInstancePayloadResultInstance {
+	return v.Result
+}
+
+// GetSuccessful returns OrphanInstanceOrphanInstanceInstancePayload.Successful, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayload) GetSuccessful() bool { return v.Successful }
+
+// GetMessages returns OrphanInstanceOrphanInstanceInstancePayload.Messages, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayload) GetMessages() []OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage {
+	return v.Messages
+}
+
+// OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage includes the requested fields of the GraphQL type ValidationMessage.
+// The GraphQL type's documentation follows.
+//
+// Validation messages are returned when mutation input does not meet the requirements.
+// While client-side validation is highly recommended to provide the best User Experience,
+// All inputs will always be validated server-side.
+//
+// Some examples of validations are:
+//
+// * Username must be at least 10 characters
+// * Email field does not contain an email address
+// * Birth Date is required
+//
+// While GraphQL has support for required values, mutation data fields are always
+// set to optional in our API. This allows 'required field' messages
+// to be returned in the same manner as other validations. The only exceptions
+// are id fields, which may be required to perform updates or deletes.
+type OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage struct {
+	// A unique error code for the type of validation used.
+	Code string `json:"code"`
+	// The input field that the error applies to. The field can be used to
+	// identify which field the error message should be displayed next to in the
+	// presentation layer.
+	//
+	// If there are multiple errors to display for a field, multiple validation
+	// messages will be in the result.
+	//
+	// This field may be null in cases where an error cannot be applied to a specific field.
+	Field string `json:"field"`
+	// A friendly error message, appropriate for display to the end user.
+	//
+	// The message is interpolated to include the appropriate variables.
+	//
+	// Example: `Username must be at least 10 characters`
+	//
+	// This message may change without notice, so we do not recommend you match against the text.
+	// Instead, use the *code* field for matching.
+	Message string `json:"message"`
+}
+
+// GetCode returns OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage.Code, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage) GetCode() string {
+	return v.Code
+}
+
+// GetField returns OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage.Field, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage) GetField() string {
+	return v.Field
+}
+
+// GetMessage returns OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage.Message, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayloadMessagesValidationMessage) GetMessage() string {
+	return v.Message
+}
+
+// OrphanInstanceOrphanInstanceInstancePayloadResultInstance includes the requested fields of the GraphQL type Instance.
+// The GraphQL type's documentation follows.
+//
+// A deployed piece of infrastructure in an environment.
+//
+// An instance is the **runtime representation** of a component. When you add a
+// "database" component to your blueprint and deploy it to the `staging`
+// environment, Massdriver creates an instance that tracks the database's
+// configuration, deployment state, costs, and produced resources.
+//
+// **Lifecycle:** Instances progress through a well-defined set of states:
+//
+// ```mermaid
+// stateDiagram-v2
+// [*] --> INITIALIZED: "Component added to environment"
+// INITIALIZED --> PROVISIONED: "Deployment succeeds"
+// INITIALIZED --> FAILED: "Deployment fails"
+// PROVISIONED --> PROVISIONED: "Redeploy / update"
+// PROVISIONED --> DECOMMISSIONED: "Decommission succeeds"
+// PROVISIONED --> FAILED: "Deployment fails"
+// FAILED --> PROVISIONED: "Retry succeeds"
+// FAILED --> DECOMMISSIONED: "Decommission"
+// ```
+//
+// **Version resolution:** Each instance has a `version` constraint (e.g., `~1.0`)
+// and a `releaseStrategy` (stable or development). Together these determine
+// the `resolvedVersion` that will be used on the next deployment. Compare
+// `resolvedVersion` with `deployedVersion` to see if a redeployment is needed,
+// or check `availableUpgrade` for newer matching releases.
+type OrphanInstanceOrphanInstanceInstancePayloadResultInstance struct {
+	Id string `json:"id"`
+	// Name of the instance.
+	Name string `json:"name"`
+	// Current lifecycle state of the instance.
+	Status InstanceStatus `json:"status"`
+}
+
+// GetId returns OrphanInstanceOrphanInstanceInstancePayloadResultInstance.Id, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayloadResultInstance) GetId() string { return v.Id }
+
+// GetName returns OrphanInstanceOrphanInstanceInstancePayloadResultInstance.Name, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayloadResultInstance) GetName() string { return v.Name }
+
+// GetStatus returns OrphanInstanceOrphanInstanceInstancePayloadResultInstance.Status, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceOrphanInstanceInstancePayloadResultInstance) GetStatus() InstanceStatus {
+	return v.Status
+}
+
+// OrphanInstanceResponse is returned by OrphanInstance on success.
+type OrphanInstanceResponse struct {
+	// Reset an instance back to `INITIALIZED`, clearing every Terraform/OpenTofu
+	// state lock and aborting any in-flight or queued deployments. Optionally
+	// deletes the remote IaC state files.
+	//
+	// Use this break-glass operation when a deployment is permanently stuck and
+	// cannot be recovered through normal retry. State locks are always cleared.
+	// Active `RUNNING`, `PENDING`, and `APPROVED` deployments are bulk-aborted
+	// so a late worker callback cannot walk the instance status back to
+	// `PROVISIONED`. Pass `deleteState: true` to also remove the
+	// Terraform/OpenTofu state files — this is **irreversible** and the next
+	// deployment will provision from scratch, potentially duplicating any
+	// resources that the prior state was tracking.
+	//
+	// ```graphql
+	// mutation {
+	// orphanInstance(
+	// organizationId: "my-org"
+	// id: "my-database"
+	// input: { deleteState: false }
+	// ) {
+	// result { id status }
+	// successful
+	// }
+	// }
+	// ```
+	OrphanInstance OrphanInstanceOrphanInstanceInstancePayload `json:"orphanInstance"`
+}
+
+// GetOrphanInstance returns OrphanInstanceResponse.OrphanInstance, and is useful for accessing the field via an interface.
+func (v *OrphanInstanceResponse) GetOrphanInstance() OrphanInstanceOrphanInstanceInstancePayload {
+	return v.OrphanInstance
+}
+
 // Filter instances by the value of a configuration parameter at a specific JSON path.
 //
 // Parameter dimensions let you slice your infrastructure by any value in an instance's
@@ -25251,6 +25421,22 @@ func (v *__ListServiceAccountsInput) GetSort() *ServiceAccountsSort { return v.S
 // GetCursor returns __ListServiceAccountsInput.Cursor, and is useful for accessing the field via an interface.
 func (v *__ListServiceAccountsInput) GetCursor() *scalars.Cursor { return v.Cursor }
 
+// __OrphanInstanceInput is used internally by genqlient
+type __OrphanInstanceInput struct {
+	OrganizationId string              `json:"organizationId"`
+	Id             string              `json:"id"`
+	Input          OrphanInstanceInput `json:"input"`
+}
+
+// GetOrganizationId returns __OrphanInstanceInput.OrganizationId, and is useful for accessing the field via an interface.
+func (v *__OrphanInstanceInput) GetOrganizationId() string { return v.OrganizationId }
+
+// GetId returns __OrphanInstanceInput.Id, and is useful for accessing the field via an interface.
+func (v *__OrphanInstanceInput) GetId() string { return v.Id }
+
+// GetInput returns __OrphanInstanceInput.Input, and is useful for accessing the field via an interface.
+func (v *__OrphanInstanceInput) GetInput() OrphanInstanceInput { return v.Input }
+
 // __ProposeDeploymentInput is used internally by genqlient
 type __ProposeDeploymentInput struct {
 	OrganizationId string                 `json:"organizationId"`
@@ -29476,6 +29662,54 @@ func ListServiceAccounts(
 	}
 
 	data_ = &ListServiceAccountsResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The mutation executed by OrphanInstance.
+const OrphanInstance_Operation = `
+mutation OrphanInstance ($organizationId: ID!, $id: ID!, $input: OrphanInstanceInput!) {
+	orphanInstance(organizationId: $organizationId, id: $id, input: $input) {
+		result {
+			id
+			name
+			status
+		}
+		successful
+		messages {
+			code
+			field
+			message
+		}
+	}
+}
+`
+
+func OrphanInstance(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	organizationId string,
+	id string,
+	input OrphanInstanceInput,
+) (data_ *OrphanInstanceResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "OrphanInstance",
+		Query:  OrphanInstance_Operation,
+		Variables: &__OrphanInstanceInput{
+			OrganizationId: organizationId,
+			Id:             id,
+			Input:          input,
+		},
+	}
+
+	data_ = &OrphanInstanceResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/massdriver/platform/instances/example_test.go
+++ b/massdriver/platform/instances/example_test.go
@@ -46,6 +46,29 @@ func ExampleService_Update() {
 	fmt.Println(inst.ResolvedVersion)
 }
 
+func ExampleService_Orphan() {
+	c, err := massdriver.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Break-glass: an instance is permanently stuck and cannot be
+	// recovered through deployments. Orphan clears the state locks and
+	// bulk-aborts any RUNNING/PENDING/APPROVED/FAILED deployments so the
+	// instance settles back to INITIALIZED.
+	//
+	// Leave DeleteState false unless the remote Terraform/OpenTofu state
+	// is known to be unrecoverable — DeleteState: true is irreversible
+	// and the next deployment may duplicate previously-tracked resources.
+	inst, err := c.Instances.Orphan(context.Background(), "ecomm-prod-database", instances.OrphanInput{
+		DeleteState: false,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(inst.Status)
+}
+
 func ExampleService_SetSecret() {
 	c, err := massdriver.NewClient()
 	if err != nil {

--- a/massdriver/platform/instances/instances.go
+++ b/massdriver/platform/instances/instances.go
@@ -300,6 +300,9 @@ func (s *Service) Update(ctx context.Context, id string, input UpdateInput) (*In
 // duplicating any resources the prior state was tracking. This is
 // irreversible — prefer leaving DeleteState false unless the state is
 // known to be unrecoverable.
+//
+// The returned [Instance] is slim (id, name, status only) — call [Service.Get]
+// if you need params, statePaths, or resources after orphaning.
 func (s *Service) Orphan(ctx context.Context, id string, input OrphanInput) (*Instance, error) {
 	resp, err := gen.OrphanInstance(ctx, s.client.GQLv2, s.client.Config.OrganizationID, id, gen.OrphanInstanceInput{
 		DeleteState: input.DeleteState,

--- a/massdriver/platform/instances/instances.go
+++ b/massdriver/platform/instances/instances.go
@@ -108,6 +108,14 @@ type UpdateInput struct {
 	Version string
 }
 
+// OrphanInput is the input for [Service.Orphan].
+type OrphanInput struct {
+	// DeleteState, when true, also deletes the remote Terraform/OpenTofu state
+	// files. This is irreversible — the next deployment will provision from
+	// scratch and may duplicate any resources tracked by the prior state.
+	DeleteState bool
+}
+
 // CopyInput is the input for [Service.Copy].
 type CopyInput struct {
 	// Overrides are deep-merged onto the source params before writing
@@ -280,6 +288,29 @@ func (s *Service) Update(ctx context.Context, id string, input UpdateInput) (*In
 		return nil, err
 	}
 	return toInstance(resp.UpdateInstance.Result)
+}
+
+// Orphan is a break-glass operation that resets a permanently-stuck instance
+// to INITIALIZED, clearing all Terraform/OpenTofu state locks. Active
+// RUNNING, PENDING, and APPROVED deployments are bulk-aborted so a late
+// worker callback cannot walk the instance status back to PROVISIONED.
+//
+// Set OrphanInput.DeleteState to also remove the remote IaC state files;
+// the next deployment will then provision from scratch, potentially
+// duplicating any resources the prior state was tracking. This is
+// irreversible — prefer leaving DeleteState false unless the state is
+// known to be unrecoverable.
+func (s *Service) Orphan(ctx context.Context, id string, input OrphanInput) (*Instance, error) {
+	resp, err := gen.OrphanInstance(ctx, s.client.GQLv2, s.client.Config.OrganizationID, id, gen.OrphanInstanceInput{
+		DeleteState: input.DeleteState,
+	})
+	if err != nil {
+		return nil, gql.ClassifyError(fmt.Errorf("orphan instance %s: %w", id, err))
+	}
+	if err := gql.CheckMutation("orphan instance", resp.OrphanInstance.Successful, resp.OrphanInstance.Messages); err != nil {
+		return nil, err
+	}
+	return toInstance(resp.OrphanInstance.Result)
 }
 
 // Copy copies configuration from sourceID to destinationID. Source and

--- a/massdriver/platform/instances/instances_test.go
+++ b/massdriver/platform/instances/instances_test.go
@@ -226,6 +226,75 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestOrphan(t *testing.T) {
+	gqlClient := gqltest.NewClient(
+		gqltest.RespondWithData(map[string]any{
+			"orphanInstance": map[string]any{
+				"result": map[string]any{
+					"id":     "ecomm-prod-database",
+					"name":   "Primary Database",
+					"status": "INITIALIZED",
+				},
+				"successful": true,
+			},
+		}),
+	)
+
+	got, err := newService(gqlClient).Orphan(t.Context(), "ecomm-prod-database", instances.OrphanInput{
+		DeleteState: true,
+	})
+	if err != nil {
+		t.Fatalf("Orphan: %v", err)
+	}
+	if got.Status != "INITIALIZED" {
+		t.Errorf("Status = %q, want INITIALIZED", got.Status)
+	}
+
+	reqs := gqlClient.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	if reqs[0].Variables["id"] != "ecomm-prod-database" {
+		t.Errorf("id variable = %v, want ecomm-prod-database", reqs[0].Variables["id"])
+	}
+	input, ok := reqs[0].Variables["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("input variable missing or wrong type: %v", reqs[0].Variables["input"])
+	}
+	if input["deleteState"] != true {
+		t.Errorf("input.deleteState = %v, want true", input["deleteState"])
+	}
+}
+
+func TestOrphan_MutationFailure(t *testing.T) {
+	gqlClient := gqltest.NewClient(
+		gqltest.RespondWithData(map[string]any{
+			"orphanInstance": map[string]any{
+				"result":     nil,
+				"successful": false,
+				"messages": []map[string]any{
+					{"code": "conflict", "field": "id", "message": "instance has no recoverable state"},
+				},
+			},
+		}),
+	)
+
+	_, err := newService(gqlClient).Orphan(t.Context(), "ecomm-prod-database", instances.OrphanInput{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	mf, ok := gql.AsMutationFailedError(err)
+	if !ok {
+		t.Fatalf("expected *gql.MutationFailedError, got %T: %v", err, err)
+	}
+	if mf.Op != "orphan instance" {
+		t.Errorf("Op = %q, want orphan instance", mf.Op)
+	}
+	if len(mf.Messages) != 1 || mf.Messages[0].Field != "id" {
+		t.Errorf("messages = %+v, want one message for field=id", mf.Messages)
+	}
+}
+
 // TestIter_StopsEarly confirms that breaking out of the range loop
 // stops further page requests — the iterator is lazy.
 func TestIter_StopsEarly(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `instances.Service.Orphan` (with `OrphanInput{DeleteState bool}`) wrapping the `orphanInstance` GraphQL mutation — resets a permanently-stuck instance to `INITIALIZED`, clears state locks, and bulk-aborts active `RUNNING`/`PENDING`/`APPROVED` deployments.
- `DeleteState: true` additionally removes the remote Terraform/OpenTofu state files; the next deployment provisions from scratch and may duplicate resources tracked by the prior state.
- Regenerated `zz_generated.go` from the new mutation in `genqlient.graphql`. No public changes elsewhere; `deployments.Abort` already covers the deployment-side cancel path.
