### PR TITLE
Add event streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,48 @@ for ev, err := range c.AuditLogs.Iter(ctx, auditlogs.ListInput{TimeRangeStart: y
 
 ## Streaming
 
-`c.Deployments.StreamLogs` and `c.Deployments.TailLogs` provide live
-deployment logs over an Absinthe websocket subscription. The Service
-owns the socket lifetime; cancel `ctx` to stop.
+The SDK exposes two flavors of live data over Absinthe WebSocket
+subscriptions. Every `Stream*` method requires a personal-access-token
+credential and returns `streaming.ErrRequiresPAT` otherwise.
+
+### Deployment logs
+
+```go
+if err := c.Deployments.TailLogs(ctx, "deploy-abc123", os.Stdout); err != nil {
+    log.Fatal(err)
+}
+```
+
+- `c.Deployments.StreamLogs` yields one `LogBatch` per provisioner flush.
+- `c.Deployments.TailLogs` is the high-level form — backfill, live tailing,
+  and terminal-state detection in one call.
+
+### Lifecycle events
+
+Each Service exposes `StreamEvents`, returning a typed `<-chan types.Event`.
+Type-assert each frame to read the affected resource:
+
+```go
+events, err := c.Instances.StreamEvents(ctx, "ecomm-prod-database")
+if err != nil { log.Fatal(err) }
+for ev := range events {
+    switch e := ev.(type) {
+    case *types.InstanceEvent:   fmt.Println(e.Action, e.Instance.Name)
+    case *types.AlarmEvent:      fmt.Println(e.Action, e.Alarm.DisplayName)
+    case *types.DeploymentEvent: fmt.Println(e.Action, e.Deployment.Status)
+    }
+}
+```
+
+| Method                          | Variants on the channel                                                                  |
+|---------------------------------|------------------------------------------------------------------------------------------|
+| `c.Organizations.StreamEvents`  | `ProjectEvent`, `OciRepoEvent`, `BundleEvent`                                            |
+| `c.Projects.StreamEvents`       | `ProjectEvent`, `EnvironmentEvent`, `ComponentEvent`, `LinkEvent`                        |
+| `c.Environments.StreamEvents`   | `EnvironmentEvent`, `EnvironmentDefaultEvent`, `InstanceEvent`, `ConnectionEvent`, `AlarmEvent`, `DeploymentEvent` |
+| `c.Instances.StreamEvents`      | `InstanceEvent`, `ConnectionEvent`, `AlarmEvent`, `DeploymentEvent`                      |
+| `c.Deployments.StreamEvents`    | `DeploymentEvent` (lifecycle transitions only — no log content)                          |
+
+The Service owns the socket lifetime; cancel `ctx` to stop.
 
 ## Testing
 

--- a/massdriver/doc.go
+++ b/massdriver/doc.go
@@ -156,10 +156,37 @@ returned error is a [*gql.MutationFailedError] — the result pointer is nil.
 
 # Streaming
 
-[deployments.Service.StreamLogs] and [deployments.Service.TailLogs]
-provide live access to deployment logs over an Absinthe websocket
-subscription. The Service owns the socket lifetime; callers only
-own the returned channel and must drain or cancel ctx to stop.
+The SDK exposes two flavors of live data over Absinthe WebSocket
+subscriptions.
+
+Deployment logs:
+
+  - [deployments.Service.StreamLogs] yields one
+    [deployments.LogBatch] per provisioner flush.
+  - [deployments.Service.TailLogs] is the high-level form that folds
+    in backfill, live tailing, and terminal-state detection.
+
+Lifecycle events — each Service's StreamEvents method opens a typed
+[types.Event] channel; callers type-assert to a concrete variant
+([*types.InstanceEvent], [*types.AlarmEvent], etc.):
+
+  - [organizations.Service.StreamEvents] — projects created, OCI
+    repositories created, bundle versions published.
+  - [projects.Service.StreamEvents] — the project itself,
+    environments, and blueprint (components, links).
+  - [environments.Service.StreamEvents] — environment defaults,
+    instances, connections, alarms, and deployments within an
+    environment.
+  - [instances.Service.StreamEvents] — instance config changes,
+    incoming connections, alarms, and deployments for a single
+    instance.
+  - [deployments.Service.StreamEvents] — lifecycle transitions for
+    a single deployment.
+
+Every Stream* method requires a personal-access-token credential and
+returns [streaming.ErrRequiresPAT] otherwise. The Service owns the
+socket lifetime; callers own the returned channel and must drain or
+cancel ctx to stop.
 
 # Stability
 

--- a/massdriver/internal/client/stream.go
+++ b/massdriver/internal/client/stream.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/config"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/absinthe"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/streaming"
+)
+
+// OpenStreamSocket gates streaming on PAT auth and opens an Absinthe
+// socket bound to the client's configured base URL and token. Used by
+// every Service.Stream* method so the auth check and dial sequence live
+// in one place.
+//
+// Returns [streaming.ErrRequiresPAT] before any network I/O when the
+// client is configured with basic-auth credentials.
+func (c *Client) OpenStreamSocket(ctx context.Context) (*absinthe.Socket, error) {
+	if c.Config.Credentials.Method != config.AuthPAT {
+		return nil, streaming.ErrRequiresPAT
+	}
+	socket, err := absinthe.Dial(ctx, c.Config.URL, c.Config.Credentials.Secret)
+	if err != nil {
+		return nil, fmt.Errorf("open absinthe socket: %w", err)
+	}
+	return socket, nil
+}

--- a/massdriver/internal/stream/events.go
+++ b/massdriver/internal/stream/events.go
@@ -1,0 +1,86 @@
+// Package stream holds the shared plumbing every domain-level
+// StreamEvents wrapper sits on top of: opening an Absinthe socket,
+// pushing the subscription, dispatching each typed frame, and tying
+// teardown to the caller's context.
+//
+// The package is internal — external callers consume it indirectly
+// through e.g. instances.Service.StreamEvents.
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/client"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+// Events opens an Absinthe subscription, decodes each frame via unpack,
+// and forwards successful unpacks on the returned channel. The channel
+// closes when ctx is cancelled, the server completes the subscription,
+// or the socket dies.
+//
+// rootField is the GraphQL field name nested under `data` (e.g.
+// "instanceEvents"); unpack reads the `__typename` inside that body and
+// returns the matching concrete [types.Event]. Frames with an unknown
+// __typename (or malformed JSON) are skipped without tearing down the
+// stream.
+//
+// opName labels the operation for error wrapping (e.g.
+// "instance events for inst-abc"). The socket and subscription are
+// closed automatically on ctx cancel — callers only own the returned
+// channel.
+func Events(
+	ctx context.Context,
+	c *client.Client,
+	opName, query string,
+	vars map[string]any,
+	unpack func(json.RawMessage) (types.Event, bool),
+) (<-chan types.Event, error) {
+	socket, err := c.OpenStreamSocket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sub, err := socket.Subscribe(ctx, query, vars)
+	if err != nil {
+		_ = socket.Close()
+		return nil, fmt.Errorf("subscribe to %s: %w", opName, err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = sub.Close()
+		_ = socket.Close()
+	}()
+
+	out := make(chan types.Event, cap(sub.Data))
+	go func() {
+		defer close(out)
+		for raw := range sub.Data {
+			ev, ok := unpack(raw)
+			if !ok {
+				continue
+			}
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// Typename extracts the __typename field from a subscription frame's
+// inner body. Returns "" if the frame is malformed or has no
+// __typename selection — callers treat that as a skip.
+func Typename(body json.RawMessage) string {
+	var probe struct {
+		Typename string `json:"__typename"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return ""
+	}
+	return probe.Typename
+}

--- a/massdriver/platform/deployments/events.go
+++ b/massdriver/platform/deployments/events.go
@@ -1,0 +1,72 @@
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/stream"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+// deploymentEventsStreamSubscription is the GraphQL subscription pushed
+// for [Service.StreamEvents]. The union has a single member
+// ([types.DeploymentEvent]) but we still query `__typename` so the
+// generic unpacker can route the frame uniformly with the other event
+// streams.
+const deploymentEventsStreamSubscription = `subscription deploymentEvents($organizationId: ID!, $deploymentId: ID!) {
+  deploymentEvents(organizationId: $organizationId, deploymentId: $deploymentId) {
+    __typename
+    ... on Event { action timestamp }
+    ... on DeploymentEvent {
+      deployment {
+        id
+        status
+        action
+        elapsedTime
+      }
+    }
+  }
+}`
+
+// StreamEvents opens an Absinthe subscription for the named deployment's
+// lifecycle events. Each frame yields a [*types.DeploymentEvent] —
+// fires on create and every status transition (PENDING → RUNNING →
+// COMPLETED). Log content is not carried; use [Service.StreamLogs] for
+// that.
+//
+// Lifetime is owned by ctx. Cancelling ctx tears down the subscription
+// and the underlying WebSocket and closes the returned channel.
+//
+// Streaming requires PAT (bearer) authentication; basic-auth callers
+// get [streaming.ErrRequiresPAT] before any network I/O.
+func (s *Service) StreamEvents(ctx context.Context, deploymentID string) (<-chan types.Event, error) {
+	return stream.Events(
+		ctx,
+		s.client,
+		"deployment events for "+deploymentID,
+		deploymentEventsStreamSubscription,
+		map[string]any{
+			"organizationId": s.client.Config.OrganizationID,
+			"deploymentId":   deploymentID,
+		},
+		unpackDeploymentEvents,
+	)
+}
+
+func unpackDeploymentEvents(raw json.RawMessage) (types.Event, bool) {
+	var env struct {
+		Body json.RawMessage `json:"deploymentEvents"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || len(env.Body) == 0 {
+		return nil, false
+	}
+	switch stream.Typename(env.Body) {
+	case "DeploymentEvent":
+		var ev types.DeploymentEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	}
+	return nil, false
+}

--- a/massdriver/platform/deployments/example_test.go
+++ b/massdriver/platform/deployments/example_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/deployments"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
 )
 
 func ExampleService_Create() {
@@ -38,5 +39,32 @@ func ExampleService_TailLogs() {
 
 	if err := c.Deployments.TailLogs(context.Background(), "deploy-abc123", os.Stdout); err != nil {
 		log.Fatal(err)
+	}
+}
+
+// StreamEvents subscribes to a single deployment's lifecycle
+// transitions — fires on create and every status flip (PENDING →
+// RUNNING → COMPLETED). Useful when you want to react to a deployment
+// reaching a terminal state without polling. For log content, use
+// TailLogs / StreamLogs instead.
+func ExampleService_StreamEvents() {
+	c, err := massdriver.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := c.Deployments.StreamEvents(ctx, "deploy-abc123")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for ev := range events {
+		e := ev.(*types.DeploymentEvent)
+		fmt.Printf("%s: deployment %s is %s\n", e.Action, e.Deployment.ID, e.Deployment.Status)
+		if deployments.IsTerminal(e.Deployment.Status) {
+			return
+		}
 	}
 }

--- a/massdriver/platform/deployments/stream.go
+++ b/massdriver/platform/deployments/stream.go
@@ -3,16 +3,13 @@ package deployments
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"time"
 
-	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/client"
-	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/config"
-	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/absinthe"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/streaming"
 )
 
 // LogBatch is one batch of deployment logs flushed by the provisioner —
@@ -21,16 +18,11 @@ import (
 // separated by `\n`.
 type LogBatch = types.DeploymentLogBatch
 
-// ErrStreamingRequiresPAT is returned by [Service.StreamLogs] (and by
-// [Service.TailLogs] when streaming is needed) when the configured
-// credentials are not a personal access token. WebSocket subscriptions
-// authenticate via a query-string token, which only works for PATs
-// (basic-auth API keys are rejected).
-//
-// Callers can [errors.Is] against this sentinel to surface a useful hint.
-var ErrStreamingRequiresPAT = errors.New(
-	"deployment log streaming requires a personal access token (set MASSDRIVER_API_KEY to a token starting with mds_/md_)",
-)
+// ErrStreamingRequiresPAT aliases [streaming.ErrRequiresPAT] so existing
+// callers that match against this name still classify the error
+// correctly under [errors.Is]. New code should reference
+// [streaming.ErrRequiresPAT] directly.
+var ErrStreamingRequiresPAT = streaming.ErrRequiresPAT
 
 // deploymentLogsSubscription is the GraphQL operation pushed on the
 // Absinthe control channel for log batches. Kept in lockstep with the
@@ -92,7 +84,7 @@ const drainGrace = 250 * time.Millisecond
 // Most callers want [Service.TailLogs] instead — it folds together backfill,
 // terminal detection, and live tailing.
 func (s *Service) StreamLogs(ctx context.Context, deploymentID string) (<-chan LogBatch, error) {
-	socket, err := openLogStreamSocket(ctx, s.client)
+	socket, err := s.client.OpenStreamSocket(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +171,7 @@ func (s *Service) TailLogs(ctx context.Context, deploymentID string, w io.Writer
 		return nil
 	}
 
-	socket, err := openLogStreamSocket(ctx, s.client)
+	socket, err := s.client.OpenStreamSocket(ctx)
 	if err != nil {
 		return err
 	}
@@ -232,20 +224,6 @@ func (s *Service) TailLogs(ctx context.Context, deploymentID string, w io.Writer
 			return ctx.Err()
 		}
 	}
-}
-
-// openLogStreamSocket gates streaming on PAT auth and opens an Absinthe
-// socket. Shared between [StreamLogs] and [TailLogs] so the auth check
-// stays in one place.
-func openLogStreamSocket(ctx context.Context, mdClient *client.Client) (*absinthe.Socket, error) {
-	if mdClient.Config.Credentials.Method != config.AuthPAT {
-		return nil, ErrStreamingRequiresPAT
-	}
-	socket, err := absinthe.Dial(ctx, mdClient.Config.URL, mdClient.Config.Credentials.Secret)
-	if err != nil {
-		return nil, fmt.Errorf("open absinthe socket: %w", err)
-	}
-	return socket, nil
 }
 
 // drainLogs reads any in-transit log batches for a brief window after a

--- a/massdriver/platform/environments/events.go
+++ b/massdriver/platform/environments/events.go
@@ -1,0 +1,120 @@
+package environments
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/stream"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+const environmentEventsSubscription = `subscription environmentEvents($organizationId: ID!, $environmentId: ID!) {
+  environmentEvents(organizationId: $organizationId, environmentId: $environmentId) {
+    __typename
+    ... on Event { action timestamp }
+    ... on EnvironmentEvent {
+      environment { id name }
+    }
+    ... on EnvironmentDefaultEvent {
+      environmentDefault {
+        id
+        resource { id name }
+      }
+    }
+    ... on InstanceEvent {
+      instance { id name status }
+    }
+    ... on ConnectionEvent {
+      connection { id fromField toField }
+    }
+    ... on AlarmEvent {
+      alarm {
+        id
+        displayName
+        currentState { id status message occurredAt }
+      }
+    }
+    ... on DeploymentEvent {
+      deployment { id status action elapsedTime }
+    }
+  }
+}`
+
+// StreamEvents opens an Absinthe subscription for events within the
+// named environment. Each frame yields one of [*types.EnvironmentEvent],
+// [*types.EnvironmentDefaultEvent], [*types.InstanceEvent],
+// [*types.ConnectionEvent], [*types.AlarmEvent], or
+// [*types.DeploymentEvent] — covering updates to the environment, its
+// default resources, every instance / connection / alarm in it, and
+// every deployment run against those instances.
+//
+// Environment creation events are delivered on the parent project's
+// subscription (the environment must exist before you can subscribe to
+// it), so callers wanting full lifecycle coverage should listen to both.
+//
+// Lifetime is owned by ctx. Cancelling ctx tears down the subscription
+// and the underlying WebSocket and closes the returned channel.
+//
+// Streaming requires PAT (bearer) authentication; basic-auth callers
+// get [streaming.ErrRequiresPAT] before any network I/O.
+func (s *Service) StreamEvents(ctx context.Context, environmentID string) (<-chan types.Event, error) {
+	return stream.Events(
+		ctx,
+		s.client,
+		"environment events for "+environmentID,
+		environmentEventsSubscription,
+		map[string]any{
+			"organizationId": s.client.Config.OrganizationID,
+			"environmentId":  environmentID,
+		},
+		unpackEnvironmentEvents,
+	)
+}
+
+func unpackEnvironmentEvents(raw json.RawMessage) (types.Event, bool) {
+	var env struct {
+		Body json.RawMessage `json:"environmentEvents"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || len(env.Body) == 0 {
+		return nil, false
+	}
+	switch stream.Typename(env.Body) {
+	case "EnvironmentEvent":
+		var ev types.EnvironmentEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "EnvironmentDefaultEvent":
+		var ev types.EnvironmentDefaultEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "InstanceEvent":
+		var ev types.InstanceEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "ConnectionEvent":
+		var ev types.ConnectionEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "AlarmEvent":
+		var ev types.AlarmEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "DeploymentEvent":
+		var ev types.DeploymentEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	}
+	return nil, false
+}

--- a/massdriver/platform/environments/example_test.go
+++ b/massdriver/platform/environments/example_test.go
@@ -1,0 +1,51 @@
+package environments_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+// StreamEvents subscribes to an environment's event feed: updates and
+// deletes for the environment itself, lifecycle events for every
+// instance / connection / alarm in it, deployments run against those
+// instances, and the environment's default-resource assignments.
+//
+// Environment creation events are delivered on the parent project's
+// subscription (c.Projects.StreamEvents), so listen to both for full
+// lifecycle coverage.
+//
+// Cancel ctx to tear down the subscription and close the channel.
+func ExampleService_StreamEvents() {
+	c, err := massdriver.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := c.Environments.StreamEvents(ctx, "ecommerce-prod")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for ev := range events {
+		switch e := ev.(type) {
+		case *types.EnvironmentEvent:
+			fmt.Printf("%s: environment %s\n", e.Action, e.Environment.Name)
+		case *types.EnvironmentDefaultEvent:
+			fmt.Printf("%s: default %s\n", e.Action, e.EnvironmentDefault.Resource.Name)
+		case *types.InstanceEvent:
+			fmt.Printf("%s: instance %s (%s)\n", e.Action, e.Instance.Name, e.Instance.Status)
+		case *types.ConnectionEvent:
+			fmt.Printf("%s: connection %s → %s\n", e.Action, e.Connection.FromField, e.Connection.ToField)
+		case *types.AlarmEvent:
+			fmt.Printf("%s: alarm %s\n", e.Action, e.Alarm.DisplayName)
+		case *types.DeploymentEvent:
+			fmt.Printf("%s: deployment %s is %s\n", e.Action, e.Deployment.ID, e.Deployment.Status)
+		}
+	}
+}

--- a/massdriver/platform/instances/events.go
+++ b/massdriver/platform/instances/events.go
@@ -1,0 +1,95 @@
+package instances
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/stream"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+const instanceEventsSubscription = `subscription instanceEvents($organizationId: ID!, $instanceId: ID!) {
+  instanceEvents(organizationId: $organizationId, instanceId: $instanceId) {
+    __typename
+    ... on Event { action timestamp }
+    ... on InstanceEvent {
+      instance { id name status }
+    }
+    ... on ConnectionEvent {
+      connection { id fromField toField }
+    }
+    ... on AlarmEvent {
+      alarm {
+        id
+        displayName
+        currentState { id status message occurredAt }
+      }
+    }
+    ... on DeploymentEvent {
+      deployment { id status action elapsedTime }
+    }
+  }
+}`
+
+// StreamEvents opens an Absinthe subscription for the named instance's
+// event feed. Each frame yields one of [*types.InstanceEvent],
+// [*types.ConnectionEvent], [*types.AlarmEvent], or [*types.DeploymentEvent]
+// — fires when the instance's configuration changes, an incoming
+// connection is added or removed, an attached alarm is registered /
+// updated / deleted (or changes firing state), or a deployment runs
+// against the instance.
+//
+// Lifetime is owned by ctx. Cancelling ctx tears down the subscription
+// and the underlying WebSocket and closes the returned channel.
+//
+// Streaming requires PAT (bearer) authentication; basic-auth callers
+// get [streaming.ErrRequiresPAT] before any network I/O.
+func (s *Service) StreamEvents(ctx context.Context, instanceID string) (<-chan types.Event, error) {
+	return stream.Events(
+		ctx,
+		s.client,
+		"instance events for "+instanceID,
+		instanceEventsSubscription,
+		map[string]any{
+			"organizationId": s.client.Config.OrganizationID,
+			"instanceId":     instanceID,
+		},
+		unpackInstanceEvents,
+	)
+}
+
+func unpackInstanceEvents(raw json.RawMessage) (types.Event, bool) {
+	var env struct {
+		Body json.RawMessage `json:"instanceEvents"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || len(env.Body) == 0 {
+		return nil, false
+	}
+	switch stream.Typename(env.Body) {
+	case "InstanceEvent":
+		var ev types.InstanceEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "ConnectionEvent":
+		var ev types.ConnectionEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "AlarmEvent":
+		var ev types.AlarmEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "DeploymentEvent":
+		var ev types.DeploymentEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	}
+	return nil, false
+}

--- a/massdriver/platform/instances/example_test.go
+++ b/massdriver/platform/instances/example_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/gql"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/instances"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
 )
 
 func ExampleService_Get() {
@@ -67,6 +68,39 @@ func ExampleService_Orphan() {
 		log.Fatal(err)
 	}
 	fmt.Println(inst.Status)
+}
+
+// StreamEvents subscribes to an instance's event feed: config changes,
+// new deployments, incoming connection wires, and alarm-state
+// transitions all arrive on a single channel. Each frame is one of a
+// handful of concrete event types — type-switch to read the payload.
+//
+// Cancel ctx to tear down the subscription and close the channel.
+func ExampleService_StreamEvents() {
+	c, err := massdriver.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := c.Instances.StreamEvents(ctx, "ecomm-prod-database")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for ev := range events {
+		switch e := ev.(type) {
+		case *types.InstanceEvent:
+			fmt.Printf("%s: instance %s (%s)\n", e.Action, e.Instance.Name, e.Instance.Status)
+		case *types.ConnectionEvent:
+			fmt.Printf("%s: connection %s → %s\n", e.Action, e.Connection.FromField, e.Connection.ToField)
+		case *types.AlarmEvent:
+			fmt.Printf("%s: alarm %s\n", e.Action, e.Alarm.DisplayName)
+		case *types.DeploymentEvent:
+			fmt.Printf("%s: deployment %s is %s\n", e.Action, e.Deployment.ID, e.Deployment.Status)
+		}
+	}
 }
 
 func ExampleService_SetSecret() {

--- a/massdriver/platform/organizations/events.go
+++ b/massdriver/platform/organizations/events.go
@@ -1,0 +1,82 @@
+package organizations
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/stream"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+const organizationEventsSubscription = `subscription organizationEvents($organizationId: ID!) {
+  organizationEvents(organizationId: $organizationId) {
+    __typename
+    ... on Event { action timestamp }
+    ... on ProjectEvent {
+      project { id name }
+    }
+    ... on OciRepoEvent {
+      ociRepo { id name reference }
+    }
+    ... on BundleEvent {
+      bundle { id name version }
+    }
+  }
+}`
+
+// StreamEvents opens an Absinthe subscription for organization-level
+// events. Each frame yields one of [*types.ProjectEvent],
+// [*types.OciRepoEvent], or [*types.BundleEvent] — fires when projects
+// are created, OCI repositories are created in the bundle catalog, or
+// bundle versions are published to those repositories.
+//
+// The configured organization id is used implicitly; no organization
+// parameter is required.
+//
+// Lifetime is owned by ctx. Cancelling ctx tears down the subscription
+// and the underlying WebSocket and closes the returned channel.
+//
+// Streaming requires PAT (bearer) authentication; basic-auth callers
+// get [streaming.ErrRequiresPAT] before any network I/O.
+func (s *Service) StreamEvents(ctx context.Context) (<-chan types.Event, error) {
+	return stream.Events(
+		ctx,
+		s.client,
+		"organization events for "+s.client.Config.OrganizationID,
+		organizationEventsSubscription,
+		map[string]any{
+			"organizationId": s.client.Config.OrganizationID,
+		},
+		unpackOrganizationEvents,
+	)
+}
+
+func unpackOrganizationEvents(raw json.RawMessage) (types.Event, bool) {
+	var env struct {
+		Body json.RawMessage `json:"organizationEvents"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || len(env.Body) == 0 {
+		return nil, false
+	}
+	switch stream.Typename(env.Body) {
+	case "ProjectEvent":
+		var ev types.ProjectEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "OciRepoEvent":
+		var ev types.OciRepoEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "BundleEvent":
+		var ev types.BundleEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	}
+	return nil, false
+}

--- a/massdriver/platform/organizations/example_test.go
+++ b/massdriver/platform/organizations/example_test.go
@@ -1,0 +1,41 @@
+package organizations_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+// StreamEvents subscribes to the organization's event feed: projects
+// created, OCI repositories created in the bundle catalog, and bundle
+// versions published to those repositories. The configured
+// organization id is used implicitly.
+//
+// Cancel ctx to tear down the subscription and close the channel.
+func ExampleService_StreamEvents() {
+	c, err := massdriver.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := c.Organizations.StreamEvents(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for ev := range events {
+		switch e := ev.(type) {
+		case *types.ProjectEvent:
+			fmt.Printf("%s: project %s\n", e.Action, e.Project.Name)
+		case *types.OciRepoEvent:
+			fmt.Printf("%s: repo %s\n", e.Action, e.OciRepo.Name)
+		case *types.BundleEvent:
+			fmt.Printf("%s: bundle %s@%s\n", e.Action, e.Bundle.Name, e.Bundle.Version)
+		}
+	}
+}

--- a/massdriver/platform/projects/events.go
+++ b/massdriver/platform/projects/events.go
@@ -1,0 +1,89 @@
+package projects
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/stream"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+const projectEventsSubscription = `subscription projectEvents($organizationId: ID!, $projectId: ID!) {
+  projectEvents(organizationId: $organizationId, projectId: $projectId) {
+    __typename
+    ... on Event { action timestamp }
+    ... on ProjectEvent {
+      project { id name }
+    }
+    ... on EnvironmentEvent {
+      environment { id name }
+    }
+    ... on ComponentEvent {
+      component { id name }
+    }
+    ... on LinkEvent {
+      link { id fromField toField }
+    }
+  }
+}`
+
+// StreamEvents opens an Absinthe subscription for events within the
+// named project. Each frame yields one of [*types.ProjectEvent],
+// [*types.EnvironmentEvent], [*types.ComponentEvent], or
+// [*types.LinkEvent] — covering the project itself, its environments,
+// and its blueprint (components and links).
+//
+// Lifetime is owned by ctx. Cancelling ctx tears down the subscription
+// and the underlying WebSocket and closes the returned channel.
+//
+// Streaming requires PAT (bearer) authentication; basic-auth callers
+// get [streaming.ErrRequiresPAT] before any network I/O.
+func (s *Service) StreamEvents(ctx context.Context, projectID string) (<-chan types.Event, error) {
+	return stream.Events(
+		ctx,
+		s.client,
+		"project events for "+projectID,
+		projectEventsSubscription,
+		map[string]any{
+			"organizationId": s.client.Config.OrganizationID,
+			"projectId":      projectID,
+		},
+		unpackProjectEvents,
+	)
+}
+
+func unpackProjectEvents(raw json.RawMessage) (types.Event, bool) {
+	var env struct {
+		Body json.RawMessage `json:"projectEvents"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || len(env.Body) == 0 {
+		return nil, false
+	}
+	switch stream.Typename(env.Body) {
+	case "ProjectEvent":
+		var ev types.ProjectEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "EnvironmentEvent":
+		var ev types.EnvironmentEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "ComponentEvent":
+		var ev types.ComponentEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	case "LinkEvent":
+		var ev types.LinkEvent
+		if err := json.Unmarshal(env.Body, &ev); err != nil {
+			return nil, false
+		}
+		return &ev, true
+	}
+	return nil, false
+}

--- a/massdriver/platform/projects/example_test.go
+++ b/massdriver/platform/projects/example_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/gql"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/projects"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
 )
 
 func ExampleService_Get() {
@@ -26,6 +27,38 @@ func ExampleService_Get() {
 		log.Fatal(err)
 	}
 	fmt.Printf("%s — %d environments\n", proj.Name, len(proj.Environments))
+}
+
+// StreamEvents subscribes to a project's event feed: changes to the
+// project itself, lifecycle events for its environments, and edits to
+// its blueprint (components added/removed, links wired/unwired).
+//
+// Cancel ctx to tear down the subscription and close the channel.
+func ExampleService_StreamEvents() {
+	c, err := massdriver.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := c.Projects.StreamEvents(ctx, "ecommerce")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for ev := range events {
+		switch e := ev.(type) {
+		case *types.ProjectEvent:
+			fmt.Printf("%s: project %s\n", e.Action, e.Project.Name)
+		case *types.EnvironmentEvent:
+			fmt.Printf("%s: environment %s\n", e.Action, e.Environment.Name)
+		case *types.ComponentEvent:
+			fmt.Printf("%s: component %s\n", e.Action, e.Component.Name)
+		case *types.LinkEvent:
+			fmt.Printf("%s: link %s → %s\n", e.Action, e.Link.FromField, e.Link.ToField)
+		}
+	}
 }
 
 func ExampleService_Create() {

--- a/massdriver/platform/types/environment_default.go
+++ b/massdriver/platform/types/environment_default.go
@@ -1,0 +1,29 @@
+package types
+
+import "time"
+
+// EnvironmentDefault is a resource pre-assigned to an [Environment] so
+// instances inherit it automatically when their connection schema
+// matches the resource type. Only one default per resource type is
+// allowed per environment.
+//
+// Resource is a slim view of the underlying resource (id / name /
+// resourceType) — call platform/resources.Get with the resource ID for
+// the full payload. Environment is populated only when the underlying
+// GraphQL query selected it.
+type EnvironmentDefault struct {
+	ID          string                     `json:"id" mapstructure:"id"`
+	Resource    EnvironmentDefaultResource `json:"resource" mapstructure:"resource"`
+	Environment *Environment               `json:"environment,omitempty" mapstructure:"environment,omitempty"`
+	CreatedAt   time.Time                  `json:"createdAt,omitzero" mapstructure:"createdAt"`
+	UpdatedAt   time.Time                  `json:"updatedAt,omitzero" mapstructure:"updatedAt"`
+}
+
+// EnvironmentDefaultResource is the slim resource view embedded on an
+// [EnvironmentDefault]. The full resource is reachable via
+// platform/resources.Get using [EnvironmentDefaultResource.ID].
+type EnvironmentDefaultResource struct {
+	ID           string        `json:"id" mapstructure:"id"`
+	Name         string        `json:"name" mapstructure:"name"`
+	ResourceType *ResourceType `json:"resourceType,omitempty" mapstructure:"resourceType,omitempty"`
+}

--- a/massdriver/platform/types/event.go
+++ b/massdriver/platform/types/event.go
@@ -1,0 +1,142 @@
+package types
+
+import "time"
+
+// EventAction is the lifecycle change carried by every [Event] — what
+// happened to the affected resource. Values mirror the platform's
+// `EventAction` enum.
+type EventAction string
+
+const (
+	// EventCreated is the action emitted when a resource is created.
+	EventCreated EventAction = "CREATED"
+	// EventUpdated is the action emitted when a resource is modified
+	// (configuration, status, or metadata changed).
+	EventUpdated EventAction = "UPDATED"
+	// EventDeleted is the action emitted when a resource is permanently
+	// removed.
+	EventDeleted EventAction = "DELETED"
+)
+
+// Event is the marker interface satisfied by every event variant yielded by
+// a `StreamEvents` subscription. The concrete variants are [ProjectEvent],
+// [EnvironmentEvent], [EnvironmentDefaultEvent], [InstanceEvent],
+// [ComponentEvent], [LinkEvent], [ConnectionEvent], [AlarmEvent],
+// [OciRepoEvent], [BundleEvent], and [DeploymentEvent].
+//
+// Type-assert to the concrete variant to read the affected resource:
+//
+//	for ev := range events {
+//	    switch e := ev.(type) {
+//	    case *types.InstanceEvent:
+//	        fmt.Println(e.Action, e.Instance.Name)
+//	    case *types.AlarmEvent:
+//	        fmt.Println(e.Action, e.Alarm.DisplayName)
+//	    }
+//	}
+//
+// Every variant embeds [EventCommon] for the shared `Action` and
+// `Timestamp` fields, reachable via field promotion.
+type Event interface {
+	isEvent()
+}
+
+// EventCommon carries the fields every event variant shares — embedded
+// into each concrete variant. Promoted via embedding so call sites read
+// e.g. `ev.(*InstanceEvent).Action` rather than going through an
+// accessor method.
+type EventCommon struct {
+	Action    EventAction `json:"action"`
+	Timestamp time.Time   `json:"timestamp"`
+}
+
+func (EventCommon) isEvent() {}
+
+// ProjectEvent is a lifecycle event for a [Project] — fires on
+// create, update, and delete. Delivered via the project,
+// organization subscriptions.
+type ProjectEvent struct {
+	EventCommon
+	Project Project `json:"project"`
+}
+
+// EnvironmentEvent is a lifecycle event for an [Environment]. Creation
+// events arrive on the parent project's subscription; updates and
+// deletes arrive on the environment's own subscription.
+type EnvironmentEvent struct {
+	EventCommon
+	Environment Environment `json:"environment"`
+}
+
+// EnvironmentDefaultEvent is a lifecycle event for an
+// [EnvironmentDefault] — emitted CREATED when a default is set and
+// DELETED when it is cleared. Defaults are paginated under the parent
+// environment, so refetch that page on receipt rather than relying on
+// cache merging.
+type EnvironmentDefaultEvent struct {
+	EventCommon
+	EnvironmentDefault EnvironmentDefault `json:"environmentDefault"`
+}
+
+// InstanceEvent is a lifecycle event for an [Instance] — fires on
+// create, configuration change, deployment, and delete.
+type InstanceEvent struct {
+	EventCommon
+	Instance Instance `json:"instance"`
+}
+
+// ComponentEvent is a lifecycle event for a [Component] — fires when
+// a component is added, renamed/re-tagged, moved on the canvas, or
+// removed from a project's blueprint.
+type ComponentEvent struct {
+	EventCommon
+	Component Component `json:"component"`
+}
+
+// LinkEvent is a lifecycle event for a blueprint [Link] — fires when
+// two components are linked or unlinked. Links have no mutable body, so
+// only CREATED and DELETED actions are emitted.
+type LinkEvent struct {
+	EventCommon
+	Link Link `json:"link"`
+}
+
+// ConnectionEvent is a lifecycle event for a [Connection] — the
+// runtime realization of a [Link] within an environment. Fires when
+// the wire is established or torn down.
+type ConnectionEvent struct {
+	EventCommon
+	Connection Connection `json:"connection"`
+}
+
+// AlarmEvent is a lifecycle event for a cloud-metric [Alarm] attached
+// to an instance. Fires on register / reconfigure / remove, and on
+// firing-state transitions (OK → ALARM, etc.) which surface as
+// UPDATED with the latest state on `Alarm.CurrentState`.
+type AlarmEvent struct {
+	EventCommon
+	Alarm Alarm `json:"alarm"`
+}
+
+// OciRepoEvent is a lifecycle event for an [OciRepo]. The registry is
+// immutable, so only CREATED is emitted today — the first time a
+// bundle is published under a new repository name.
+type OciRepoEvent struct {
+	EventCommon
+	OciRepo OciRepo `json:"ociRepo"`
+}
+
+// BundleEvent is a lifecycle event for a published [Bundle] version.
+// Bundle versions are immutable, so only CREATED is emitted today.
+type BundleEvent struct {
+	EventCommon
+	Bundle Bundle `json:"bundle"`
+}
+
+// DeploymentEvent is a lifecycle event for a [Deployment] — emitted
+// on create (CREATED) and each status transition (UPDATED). Log
+// content is not carried; subscribe via `StreamLogs` for that.
+type DeploymentEvent struct {
+	EventCommon
+	Deployment Deployment `json:"deployment"`
+}

--- a/massdriver/streaming/streaming.go
+++ b/massdriver/streaming/streaming.go
@@ -1,0 +1,26 @@
+// Package streaming holds primitives shared by every Massdriver SDK
+// streaming subscription.
+//
+// The Service-level streaming methods live in their per-domain packages
+// ([deployments.Service.StreamLogs], [instances.Service.StreamEvents],
+// etc.); this package only exposes the cross-cutting sentinels callers
+// need to classify errors with [errors.Is].
+package streaming
+
+import "errors"
+
+// ErrRequiresPAT is returned by every Stream* operation when the
+// configured credentials are not a personal access token. WebSocket
+// subscriptions authenticate via a query-string token that only works
+// for PATs — basic-auth API keys are rejected by the server's
+// UserSocket.
+//
+// Match with [errors.Is]:
+//
+//	_, err := c.Instances.StreamEvents(ctx, id)
+//	if errors.Is(err, streaming.ErrRequiresPAT) {
+//	    // surface a hint to set MASSDRIVER_API_KEY to a mds_/md_ token
+//	}
+var ErrRequiresPAT = errors.New(
+	"streaming requires a personal access token (set MASSDRIVER_API_KEY to a token starting with mds_/md_)",
+)


### PR DESCRIPTION
## Summary

Wraps the 5 remaining platform GraphQL subscriptions as `Service.StreamEvents` methods so callers don't have to drop into `internal/absinthe`. Previously only `deployments.StreamLogs` / `TailLogs` were wrapped.

## What's new

- `c.Organizations.StreamEvents(ctx)` — projects created, OCI repositories created, bundle versions published
- `c.Projects.StreamEvents(ctx, projectID)` — the project, its environments, and its blueprint (components, links)
- `c.Environments.StreamEvents(ctx, envID)` — environment + defaults, every instance / connection / alarm in it, and deployments run against them
- `c.Instances.StreamEvents(ctx, instanceID)` — instance config changes, incoming connections, alarms, deployments
- `c.Deployments.StreamEvents(ctx, deploymentID)` — lifecycle transitions for one deployment (no log content; use `StreamLogs` for that)

Each returns `<-chan types.Event`. Callers type-assert to the concrete variant:

```go
events, err := c.Instances.StreamEvents(ctx, "ecomm-prod-database")
for ev := range events {
    switch e := ev.(type) {
    case *types.InstanceEvent:   fmt.Println(e.Action, e.Instance.Name)
    case *types.AlarmEvent:      fmt.Println(e.Action, e.Alarm.DisplayName)
    case *types.DeploymentEvent: fmt.Println(e.Action, e.Deployment.Status)
    }
}
```

## Design
* Event shape: an Event marker interface in platform/types plus 11 concrete variants (ProjectEvent, EnvironmentEvent, EnvironmentDefaultEvent, InstanceEvent, ComponentEvent, LinkEvent, ConnectionEvent, AlarmEvent, OciRepoEvent, BundleEvent, DeploymentEvent). Each embeds EventCommon (Action, Timestamp) and adds the affected resource. Server frames carry __typename for dispatch.
* PAT sentinel: new public massdriver/streaming package owns the canonical ErrRequiresPAT. deployments.ErrStreamingRequiresPAT is kept as a backward-compat alias so existing errors.Is(...) matches keep working.
* Shared plumbing: (*client.Client).OpenStreamSocket(ctx) centralises the PAT gate + Absinthe dial; internal/stream.Events runs the subscribe / dispatch / teardown loop. The 5 wrappers each contribute only a GraphQL subscription doc and a __typename-switch unpacker.
* New type: types.EnvironmentDefault (with slim EnvironmentDefaultResource) — needed for the EnvironmentDefaultEvent variant; the platform schema had it but the SDK didn't model it yet.

## Docs
* README.md Streaming section now has a logs block, a lifecycle-events block with a usage snippet, and a table of every StreamEvents method and its possible variants.
* doc.go Streaming section mirrors that.
* Each of the 5 packages has a runnable ExampleService_StreamEvents rendered on pkg.go.dev.