### PR TITLE
Drop `CopyInstanceInput.Message` (field removed from V2 schema)

### DIFF
--- a/massdriver/internal/gen/schema.graphql
+++ b/massdriver/internal/gen/schema.graphql
@@ -2465,9 +2465,9 @@ type RootMutationType {
 
   Both instances must be built from the same component. Source params (minus any
   fields the bundle marks non-copyable) are written to the destination, deep-merged
-  with any `overrides`. A plan deployment is then created on the destination so the
-  caller can review the changes before applying them. `copySecrets` and
-  `copyRemoteReferences` opt in to additional state transfer.
+  with any `overrides`. `copySecrets` and `copyRemoteReferences` opt in to additional
+  state transfer. Deployment is a separate action — call `createDeployment` on the
+  destination when you're ready to apply.
 
   ```graphql
   mutation {
@@ -2475,7 +2475,7 @@ type RootMutationType {
       organizationId: "my-org"
       sourceId: "ecomm-prod-db"
       destinationId: "ecomm-staging-db"
-      input: { overrides: { size: "small" }, copySecrets: true, message: "Promote prod config" }
+      input: { overrides: { size: "small" }, copySecrets: true }
     ) {
       result { id params }
       successful
@@ -2493,7 +2493,7 @@ type RootMutationType {
     "The instance to copy configuration into. Must be built from the same component as the source."
     destinationId: ID!
 
-    "Copy configuration from one instance to another. The source and destination must be instances of the same component. Source params (minus any fields marked non-copyable in the bundle) are written to the destination, then a plan deployment is created on the destination so the changes can be reviewed before applying."
+    "Copy configuration from one instance to another. The source and destination must be instances of the same component. Source params (minus any fields marked non-copyable in the bundle) are written to the destination. Deployment is a separate action — call `createDeployment` on the destination when you're ready to apply."
     input: CopyInstanceInput!
   ): InstancePayload @inputs(name: "copyInstance", schema: "\/graphql\/v2\/inputs\/copyInstance.json", ui: "\/graphql\/v2\/inputs\/copyInstance.ui.json")
 
@@ -6936,16 +6936,13 @@ input SetInstanceSecretInput {
   value: String!
 }
 
-"Copy configuration from one instance to another. The source and destination must be instances of the same component. Source params (minus any fields marked non-copyable in the bundle) are written to the destination, then a plan deployment is created on the destination so the changes can be reviewed before applying."
+"Copy configuration from one instance to another. The source and destination must be instances of the same component. Source params (minus any fields marked non-copyable in the bundle) are written to the destination. Deployment is a separate action — call `createDeployment` on the destination when you're ready to apply."
 input CopyInstanceInput {
   "When true, copies remote resource references from the source instance to the destination. Defaults to false."
   copyRemoteReferences: Boolean
 
   "When true, copies secret values from the source instance to the destination. Defaults to false."
   copySecrets: Boolean
-
-  "An optional message attached to the plan deployment created on the destination, similar to a commit message."
-  message: String
 
   "Optional overrides that are deep-merged onto the source params before writing to the destination. Useful for tweaking environment-specific values (e.g., instance sizes)."
   overrides: Map

--- a/massdriver/internal/gen/zz_generated.go
+++ b/massdriver/internal/gen/zz_generated.go
@@ -1744,14 +1744,12 @@ func (v *CopyInstanceCopyInstanceInstancePayloadResultInstance) __premarshalJSON
 	return &retval, nil
 }
 
-// Copy configuration from one instance to another. The source and destination must be instances of the same component. Source params (minus any fields marked non-copyable in the bundle) are written to the destination, then a plan deployment is created on the destination so the changes can be reviewed before applying.
+// Copy configuration from one instance to another. The source and destination must be instances of the same component. Source params (minus any fields marked non-copyable in the bundle) are written to the destination. Deployment is a separate action — call `createDeployment` on the destination when you're ready to apply.
 type CopyInstanceInput struct {
 	// When true, copies remote resource references from the source instance to the destination. Defaults to false.
 	CopyRemoteReferences bool `json:"copyRemoteReferences"`
 	// When true, copies secret values from the source instance to the destination. Defaults to false.
 	CopySecrets bool `json:"copySecrets"`
-	// An optional message attached to the plan deployment created on the destination, similar to a commit message.
-	Message string `json:"message"`
 	// Optional overrides that are deep-merged onto the source params before writing to the destination. Useful for tweaking environment-specific values (e.g., instance sizes).
 	Overrides map[string]any `json:"-"`
 }
@@ -1761,9 +1759,6 @@ func (v *CopyInstanceInput) GetCopyRemoteReferences() bool { return v.CopyRemote
 
 // GetCopySecrets returns CopyInstanceInput.CopySecrets, and is useful for accessing the field via an interface.
 func (v *CopyInstanceInput) GetCopySecrets() bool { return v.CopySecrets }
-
-// GetMessage returns CopyInstanceInput.Message, and is useful for accessing the field via an interface.
-func (v *CopyInstanceInput) GetMessage() string { return v.Message }
 
 // GetOverrides returns CopyInstanceInput.Overrides, and is useful for accessing the field via an interface.
 func (v *CopyInstanceInput) GetOverrides() map[string]any { return v.Overrides }
@@ -1806,8 +1801,6 @@ type __premarshalCopyInstanceInput struct {
 
 	CopySecrets bool `json:"copySecrets"`
 
-	Message string `json:"message"`
-
 	Overrides json.RawMessage `json:"overrides"`
 }
 
@@ -1824,7 +1817,6 @@ func (v *CopyInstanceInput) __premarshalJSON() (*__premarshalCopyInstanceInput, 
 
 	retval.CopyRemoteReferences = v.CopyRemoteReferences
 	retval.CopySecrets = v.CopySecrets
-	retval.Message = v.Message
 	{
 
 		dst := &retval.Overrides
@@ -1846,9 +1838,9 @@ type CopyInstanceResponse struct {
 	//
 	// Both instances must be built from the same component. Source params (minus any
 	// fields the bundle marks non-copyable) are written to the destination, deep-merged
-	// with any `overrides`. A plan deployment is then created on the destination so the
-	// caller can review the changes before applying them. `copySecrets` and
-	// `copyRemoteReferences` opt in to additional state transfer.
+	// with any `overrides`. `copySecrets` and `copyRemoteReferences` opt in to additional
+	// state transfer. Deployment is a separate action — call `createDeployment` on the
+	// destination when you're ready to apply.
 	//
 	// ```graphql
 	// mutation {
@@ -1856,7 +1848,7 @@ type CopyInstanceResponse struct {
 	// organizationId: "my-org"
 	// sourceId: "ecomm-prod-db"
 	// destinationId: "ecomm-staging-db"
-	// input: { overrides: { size: "small" }, copySecrets: true, message: "Promote prod config" }
+	// input: { overrides: { size: "small" }, copySecrets: true }
 	// ) {
 	// result { id params }
 	// successful

--- a/massdriver/platform/instances/instances.go
+++ b/massdriver/platform/instances/instances.go
@@ -121,9 +121,6 @@ type CopyInput struct {
 	// Overrides are deep-merged onto the source params before writing
 	// to the destination. Useful for environment-specific tweaks.
 	Overrides map[string]any
-	// Message is attached to the plan deployment created on the
-	// destination, similar to a commit message.
-	Message string
 	// CopySecrets, when true, copies secret values from the source
 	// instance to the destination.
 	CopySecrets bool
@@ -324,7 +321,6 @@ func (s *Service) Orphan(ctx context.Context, id string, input OrphanInput) (*In
 func (s *Service) Copy(ctx context.Context, sourceID, destinationID string, input CopyInput) (*Instance, error) {
 	resp, err := gen.CopyInstance(ctx, s.client.GQLv2, s.client.Config.OrganizationID, sourceID, destinationID, gen.CopyInstanceInput{
 		Overrides:            input.Overrides,
-		Message:              input.Message,
 		CopySecrets:          input.CopySecrets,
 		CopyRemoteReferences: input.CopyRemoteReferences,
 	})

--- a/massdriver/platform/instances/instances_test.go
+++ b/massdriver/platform/instances/instances_test.go
@@ -373,7 +373,6 @@ func TestCopy(t *testing.T) {
 
 	got, err := newService(gqlClient).Copy(t.Context(), "ecomm-prod-db", "ecomm-staging-db", instances.CopyInput{
 		Overrides:   map[string]any{"size": "small"},
-		Message:     "promote prod config to staging",
 		CopySecrets: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

`copyInstance` is broken in the current SDK build: every call fails at the GraphQL parser before reaching the resolver.

```
input:3: Argument "input" has invalid value $input.
In field "message": Unknown field.
```

The V2 schema dropped `message` from `CopyInstanceInput` — copy is a pure config-staging operation; messages live on the `createDeployment` that follows. The SDK was generated when `message` was on the input and still carries it, with no `omitempty`, so every call marshals `\"message\": \"\"` and gets rejected.

This regenerates the genqlient client against the current prod schema and drops `Message` from the public `instances.CopyInput`.

## Changes

- `massdriver/internal/gen/schema.graphql` — refreshed from `https://api.massdriver.cloud/graphql/v2/schema.graphql`. `CopyInstanceInput` loses `message`.
- `massdriver/internal/gen/zz_generated.go` — regenerated (`make generate`). `CopyInstanceInput` struct + getters + (un)marshal helpers drop `Message`.
- `massdriver/platform/instances/instances.go` — drop `Message string` from `CopyInput`; drop it from the gen-level mapping in `Service.Copy`.
- `massdriver/platform/instances/instances_test.go` — fixture stops setting `Message`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [ ] CI

Fixes #23. Unblocks massdriver-cloud/mass#236 and massdriver-cloud/mass#238.