### PR TITLE
Omit empty `releaseStrategy` from UpdateInstanceInput

### DIFF
--- a/massdriver/internal/gen/genqlient.graphql
+++ b/massdriver/internal/gen/genqlient.graphql
@@ -1093,7 +1093,12 @@ query ListInstances(
   }
 }
 
-mutation UpdateInstance($organizationId: ID!, $id: ID!, $input: UpdateInstanceInput!) {
+# @genqlient(for: "UpdateInstanceInput.releaseStrategy", omitempty: true, pointer: true)
+mutation UpdateInstance(
+  $organizationId: ID!,
+  $id: ID!,
+  $input: UpdateInstanceInput!
+) {
   updateInstance(organizationId: $organizationId, id: $id, input: $input) {
     result {
       id

--- a/massdriver/internal/gen/genqlient.graphql
+++ b/massdriver/internal/gen/genqlient.graphql
@@ -1093,6 +1093,11 @@ query ListInstances(
   }
 }
 
+# Multi-line operation: genqlient v0.8.1 can't associate a `for:` directive
+# with a single-line operation — the parser attributes the comment to the
+# first variable definition on the same line and rejects `for:` with
+# "for is only applicable to operations and arguments". Every `for:`-bearing
+# mutation in this file is multi-line for the same reason.
 # @genqlient(for: "UpdateInstanceInput.releaseStrategy", omitempty: true, pointer: true)
 mutation UpdateInstance(
   $organizationId: ID!,

--- a/massdriver/internal/gen/zz_generated.go
+++ b/massdriver/internal/gen/zz_generated.go
@@ -22551,13 +22551,13 @@ func (v *UpdateInstanceAlarmUpdateInstanceAlarmAlarmPayloadResultAlarmMetricDime
 // Update an instance's version. Changes take effect on the next deployment.
 type UpdateInstanceInput struct {
 	// Deprecated. Add `+dev` to `version` instead (e.g., `latest+dev`).
-	ReleaseStrategy ReleaseStrategy `json:"releaseStrategy"`
+	ReleaseStrategy *ReleaseStrategy `json:"releaseStrategy,omitempty"`
 	// Bundle version to deploy. Accepts a pinned tag (`1.2.3`), a release channel (`latest`, `~1.2`), or a release channel with `+dev` to include pre-release builds (`latest+dev`, `~1.2+dev`).
 	Version string `json:"version"`
 }
 
 // GetReleaseStrategy returns UpdateInstanceInput.ReleaseStrategy, and is useful for accessing the field via an interface.
-func (v *UpdateInstanceInput) GetReleaseStrategy() ReleaseStrategy { return v.ReleaseStrategy }
+func (v *UpdateInstanceInput) GetReleaseStrategy() *ReleaseStrategy { return v.ReleaseStrategy }
 
 // GetVersion returns UpdateInstanceInput.Version, and is useful for accessing the field via an interface.
 func (v *UpdateInstanceInput) GetVersion() string { return v.Version }

--- a/massdriver/internal/gen/zz_generated.go
+++ b/massdriver/internal/gen/zz_generated.go
@@ -30441,6 +30441,11 @@ mutation UpdateInstance ($organizationId: ID!, $id: ID!, $input: UpdateInstanceI
 }
 `
 
+// Multi-line operation: genqlient v0.8.1 can't associate a `for:` directive
+// with a single-line operation — the parser attributes the comment to the
+// first variable definition on the same line and rejects `for:` with
+// "for is only applicable to operations and arguments". Every `for:`-bearing
+// mutation in this file is multi-line for the same reason.
 func UpdateInstance(
 	ctx_ context.Context,
 	client_ graphql.Client,


### PR DESCRIPTION
## Summary

`mdClient.Instances.Update(ctx, id, instances.UpdateInput{Version: "latest+dev"})` fails before reaching the resolver:

```
input:3: Argument "input" has invalid value $input.
In field "releaseStrategy": Expected type "ReleaseStrategy", found "".
```

The V2 schema's `UpdateInstanceInput` marks `releaseStrategy` as deprecated and nullable. Clients that followed the migration to the `+dev` suffix on `version` shouldn't have to send the field anymore. In practice they couldn't, because the generated `gen.UpdateInstanceInput` emitted `"releaseStrategy": ""` whenever a caller left it unset, and Absinthe rejects the empty string against the `ReleaseStrategy` enum.

So every deprecation-following caller of `Instances.Update` was broken — every `mass instance version <id>@latest+dev` invocation, every preview command's per-instance version override, etc.

Same shape as #24 (`CopyInstanceInput.Message`), different field; the previous fix was a schema removal but this field is still in the schema (just deprecated), so this PR uses a genqlient directive instead.

## Change

One genqlient directive on the operation:

```graphql
# @genqlient(for: "UpdateInstanceInput.releaseStrategy", omitempty: true, pointer: true)
mutation UpdateInstance(
  $organizationId: ID!,
  $id: ID!,
  $input: UpdateInstanceInput!
) { ... }
```

Regenerated `zz_generated.go`. The field's Go shape moves from typed string to `*ReleaseStrategy` with `omitempty` — nil pointer ⇒ field absent on the wire, matching the deprecated + nullable schema contract.

Public `instances.UpdateInput` already only exposes `Version`, so nothing in the wrapper changes — the gen-level mapping `gen.UpdateInstanceInput{Version: input.Version}` keeps working.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [ ] CI

Fixes #25. Unblocks massdriver-cloud/mass#236 and #238.