### PR TITLE
Improvements to resources endpoint to support debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.html
 # Direnv & tooling
 .envrc
 .env
+env
 
 # OS
 Thumbs.db

--- a/massdriver/provisioning/resources/resources.go
+++ b/massdriver/provisioning/resources/resources.go
@@ -5,19 +5,31 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/client"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/internal/rest"
 )
 
 // ErrNotFound is returned when the REST endpoint responds with HTTP 404.
 // Match with [errors.Is].
 var ErrNotFound = errors.New("not found")
 
+// Resource is the create/update/show payload for /v1/resources.
+//
+// The server dispatches on presence of `field` in the body: bodies with
+// `field` set go through the provisioned-artifact path (deployment token
+// auth, type inferred from the deployment's package); bodies without it
+// go through the imported-artifact path (requires `type`). `omitempty`
+// on every optional field is what keeps these two flows distinct on the
+// wire — do not remove it.
 type Resource struct {
-	ID      string                 `json:"id"`
-	Field   string                 `json:"field"`
-	Type    string                 `json:"type"`
-	Name    string                 `json:"name"`
+	ID      string                 `json:"id,omitempty"`
+	Field   string                 `json:"field,omitempty"`
+	Type    string                 `json:"type,omitempty"`
+	Name    string                 `json:"name,omitempty"`
 	Payload map[string]interface{} `json:"payload"`
 }
 
@@ -43,7 +55,7 @@ func (s *Service) CreateResource(ctx context.Context, a *Resource) (*Resource, e
 		return nil, err
 	}
 	if resp.IsError() {
-		return nil, fmt.Errorf("create resource failed: %s", resp.Status())
+		return nil, formatAPIError("create resource", resp)
 	}
 	return &result, nil
 }
@@ -63,7 +75,7 @@ func (s *Service) GetResource(ctx context.Context, id string) (*Resource, error)
 		return nil, fmt.Errorf("get resource %s: %w", id, ErrNotFound)
 	}
 	if resp.IsError() {
-		return nil, fmt.Errorf("get resource failed: %s", resp.Status())
+		return nil, formatAPIError("get resource "+id, resp)
 	}
 	return &result, nil
 }
@@ -84,19 +96,15 @@ func (s *Service) UpdateResource(ctx context.Context, id string, a *Resource) (*
 		return nil, fmt.Errorf("update resource %s: %w", id, ErrNotFound)
 	}
 	if resp.IsError() {
-		return nil, fmt.Errorf("update resource failed: %s", resp.Status())
+		return nil, formatAPIError("update resource "+id, resp)
 	}
 	return &result, nil
 }
 
-// DeleteResource sends a DELETE /v1/resources/:id with metadata.field in the body
-func (s *Service) DeleteResource(ctx context.Context, id, field string) error {
-	payload := map[string]interface{}{
-		"field": field,
-	}
+// DeleteResource sends a DELETE /v1/resources/:id request.
+func (s *Service) DeleteResource(ctx context.Context, id string) error {
 	resp, err := s.client.HTTP.R().
 		SetContext(ctx).
-		SetBody(payload).
 		Delete("/v1/resources/" + id)
 
 	if err != nil {
@@ -105,8 +113,34 @@ func (s *Service) DeleteResource(ctx context.Context, id, field string) error {
 	if resp.StatusCode() == http.StatusNotFound {
 		return fmt.Errorf("delete resource %s: %w", id, ErrNotFound)
 	}
-	if resp.StatusCode() != http.StatusOK {
-		return fmt.Errorf("delete resource failed: %s", resp.Status())
+	if resp.IsError() {
+		return formatAPIError("delete resource "+id, resp)
 	}
 	return nil
+}
+
+// formatAPIError builds an error that includes the server's JSON error
+// body when one is present, so callers see e.g. "payload: can't be blank"
+// instead of a bare "422 Unprocessable Entity".
+func formatAPIError(op string, resp *resty.Response) error {
+	errResp, parseErr := rest.ParseJSONErrorResponse(resp)
+	if parseErr != nil {
+		return fmt.Errorf("%s: %d: %s", op, resp.StatusCode(), strings.TrimSpace(string(resp.Body())))
+	}
+	if errResp.IsValidationError() {
+		fields := make([]string, 0, len(errResp.Errors))
+		for k := range errResp.Errors {
+			fields = append(fields, k)
+		}
+		sort.Strings(fields)
+		parts := make([]string, 0, len(fields))
+		for _, k := range fields {
+			parts = append(parts, fmt.Sprintf("%s: %s", k, strings.Join(errResp.Errors[k], ", ")))
+		}
+		return fmt.Errorf("%s: %d: %s", op, resp.StatusCode(), strings.Join(parts, "; "))
+	}
+	if errResp.IsFrameworkError() {
+		return fmt.Errorf("%s: %d: %s", op, resp.StatusCode(), errResp.Error)
+	}
+	return fmt.Errorf("%s: %d", op, resp.StatusCode())
 }

--- a/massdriver/provisioning/resources/resources_test.go
+++ b/massdriver/provisioning/resources/resources_test.go
@@ -3,6 +3,7 @@ package resources_test
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -23,6 +24,43 @@ func newTestClient(r *mockhttp.MockHTTPResponse) (*client.Client, *mockhttp.Muta
 	return &client.Client{
 		HTTP: httpClient,
 	}, &roundtripper
+}
+
+// Empty Field/Type/ID/Name must not appear in the wire body — the server
+// dispatches on presence of "field" in the body, so an unset Field would
+// route an imported-artifact create to the provisioned handler.
+func TestCreateResource_OmitsEmptyFields(t *testing.T) {
+	client, roundTripper := newTestClient(&mockhttp.MockHTTPResponse{StatusCode: 201, Body: `{"id":"abc"}`})
+	service := resources.NewService(client)
+
+	_, err := service.CreateResource(context.Background(), &resources.Resource{
+		Type:    "cloud/db",
+		Name:    "imported-only",
+		Payload: map[string]interface{}{"data": map[string]string{"k": "v"}},
+	})
+	require.NoError(t, err)
+
+	gotBody, err := io.ReadAll(roundTripper.ReceivedRequest.Body)
+	require.NoError(t, err)
+	require.JSONEq(t,
+		`{"type":"cloud/db","name":"imported-only","payload":{"data":{"k":"v"}}}`,
+		string(gotBody),
+	)
+}
+
+// Error responses must surface the server's JSON body so 422s are debuggable.
+func TestCreateResource_SurfacesServerError(t *testing.T) {
+	client, _ := newTestClient(&mockhttp.MockHTTPResponse{
+		StatusCode: 422,
+		Body:       `{"errors":{"payload":["can't be blank"]}}`,
+	})
+	service := resources.NewService(client)
+
+	_, err := service.CreateResource(context.Background(), &resources.Resource{Field: "network"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "payload")
+	require.Contains(t, err.Error(), "can't be blank")
+	require.True(t, strings.Contains(err.Error(), "422"), "expected status in error, got: %s", err.Error())
 }
 
 func TestCreateResource(t *testing.T) {
@@ -192,14 +230,12 @@ func TestDeleteResource(t *testing.T) {
 	tests := []struct {
 		name         string
 		status       int
-		sentBody     string
 		responseBody string
 		expectErr    bool
 	}{
 		{
 			name:      "success",
 			status:    200,
-			sentBody:  `{"field":"db"}`,
 			expectErr: false,
 		},
 		{
@@ -215,16 +251,13 @@ func TestDeleteResource(t *testing.T) {
 			client, roundTripper := newTestClient(&mockhttp.MockHTTPResponse{StatusCode: tt.status, Body: tt.responseBody})
 			service := resources.NewService(client)
 
-			err := service.DeleteResource(context.Background(), "abc-123", "db")
+			err := service.DeleteResource(context.Background(), "abc-123")
 
 			if tt.expectErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-
-				gotBody, err := io.ReadAll(roundTripper.ReceivedRequest.Body)
-				require.NoError(t, err)
-				require.JSONEq(t, tt.sentBody, string(gotBody))
+				require.Nil(t, roundTripper.ReceivedRequest.Body)
 			}
 		})
 	}


### PR DESCRIPTION
Summary of changes:


Changes to `massdriver/provisioning/resources/resources.go`

- Added omitempty to ID, Field, Type, Name JSON tags (left Payload alone — nil should surface as a clean server error). Added a comment on the struct explaining why omitempty matters here so a future contributor doesn't innocently remove it.
- Added formatAPIError helper that parses the server's JSON error body via `rest.ParseJSONErrorResponse` and renders it like create resource: 422: payload: can't be blank. Wired into every method.
- Dropped the field arg from DeleteResource — the Elixir controller's `delete` only pattern-matches on %{"id" => artifact_identifier} from the URL; it never reads the body.

Changes to `resources_test.go`

- Added TestCreateResource_OmitsEmptyFields — proves a Resource with only Type + Name + Payload serializes without a "field":"" key (the bug that was misrouting imported creates).
- Added TestCreateResource_SurfacesServerError — proves a 422 with {"errors":{"payload":["can't be blank"]}} produces an error string containing both payload and can't be blank.
- Updated TestDeleteResource for the new no-body signature.